### PR TITLE
fix issue with type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,10 +18,8 @@ declare module "react-native-raw-bottom-sheet" {
     };
   };
 
-  class RBSheet extends Component<RBSheetProps> {
+  export default class RBSheet extends Component<RBSheetProps> {
     open(): void;
     close(): void;
   }
-
-  export default RBSheet;
 }


### PR DESCRIPTION
# fix issue with type declaration

I had an issue compiling the library using typescript Version 3.6.4

```
node_modules/react-native-raw-bottom-sheet/index.d.ts:26:3 - error TS2666: Exports and export assignments are not permitted in module augmentations.

26   export default RBSheet;
     ~~~~~~

Found 1 error.
```

The error is fixed with the simple patch provided in the PR