### PR TITLE
Add prop to allow dragging from top area only

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,8 @@ class RBSheet extends Component {
       closeOnPressBack,
       children,
       customStyles,
-      keyboardAvoidingViewEnabled
+      keyboardAvoidingViewEnabled,
+      dragFromTop,
     } = this.props;
     const { animatedHeight, pan, modalVisible } = this.state;
     const panStyle = {
@@ -121,11 +122,11 @@ class RBSheet extends Component {
             onPress={() => (closeOnPressMask ? this.close() : null)}
           />
           <Animated.View
-            {...this.panResponder.panHandlers}
+            {...(!dragFromTop && this.panResponder.panHandlers)}
             style={[panStyle, styles.container, { height: animatedHeight }, customStyles.container]}
           >
             {closeOnDragDown && (
-              <View style={styles.draggableContainer}>
+              <View {...(dragFromTop && this.panResponder.panHandlers)} style={styles.draggableContainer}>
                 <View style={[styles.draggableIcon, customStyles.draggableIcon]} />
               </View>
             )}
@@ -149,7 +150,8 @@ RBSheet.propTypes = {
   customStyles: PropTypes.objectOf(PropTypes.object),
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
-  children: PropTypes.node
+  children: PropTypes.node,
+  dragFromTop: PropTypes.bool,
 };
 
 RBSheet.defaultProps = {
@@ -164,7 +166,8 @@ RBSheet.defaultProps = {
   customStyles: {},
   onClose: null,
   onOpen: null,
-  children: <View />
+  children: <View />,
+  dragFromTop: false,
 };
 
 export default RBSheet;


### PR DESCRIPTION
This new prop, `dragFromTop`, will allow users to drag only the top are of the view to close it instead of the whole view. This easily fixes the issue of not being able to scroll inside of it when `closeOnDragDown` is true.

In my case, I am using a `WebView` inside of the `BottomSheet` and wasn't allowing me to scroll.
I haven't faced any issues so far.

Thought it might be helpful to others :)