### PR TITLE
Specify native driver for Animated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 
 # Jest Test Coverage
 coverage/
+
+# Ignore editor config
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -3798,8 +3798,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3820,14 +3819,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3842,20 +3839,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3972,8 +3966,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3985,7 +3978,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4000,7 +3992,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4008,14 +3999,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4034,7 +4023,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4115,8 +4103,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4128,7 +4115,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4214,8 +4200,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4251,7 +4236,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4271,7 +4255,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4315,14 +4298,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ class RBSheet extends Component {
         if (height / 4 - gestureState.dy < 0) {
           this.setModalVisible(false);
         } else {
-          Animated.spring(pan, { toValue: { x: 0, y: 0 } }).start();
+          Animated.spring(pan, { toValue: { x: 0, y: 0 }, useNativeDriver: false }).start();
         }
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -38,11 +38,13 @@ class RBSheet extends Component {
       this.setState({ modalVisible: visible });
       if (typeof onOpen === "function") onOpen(props);
       Animated.timing(animatedHeight, {
+        useNativeDriver: true,
         toValue: height,
         duration
       }).start();
     } else {
       Animated.timing(animatedHeight, {
+        useNativeDriver: true,
         toValue: minClosingHeight,
         duration
       }).start(() => {
@@ -64,7 +66,7 @@ class RBSheet extends Component {
       onStartShouldSetPanResponder: () => closeOnDragDown,
       onPanResponderMove: (e, gestureState) => {
         if (gestureState.dy > 0) {
-          Animated.event([null, { dy: pan.y }])(e, gestureState);
+          Animated.event([null, { dy: pan.y }], { useNativeDriver: true })(e, gestureState);
         }
       },
       onPanResponderRelease: (e, gestureState) => {

--- a/src/index.js
+++ b/src/index.js
@@ -38,13 +38,13 @@ class RBSheet extends Component {
       this.setState({ modalVisible: visible });
       if (typeof onOpen === "function") onOpen(props);
       Animated.timing(animatedHeight, {
-        useNativeDriver: true,
+        useNativeDriver: false,
         toValue: height,
         duration
       }).start();
     } else {
       Animated.timing(animatedHeight, {
-        useNativeDriver: true,
+        useNativeDriver: false,
         toValue: minClosingHeight,
         duration
       }).start(() => {
@@ -66,7 +66,7 @@ class RBSheet extends Component {
       onStartShouldSetPanResponder: () => closeOnDragDown,
       onPanResponderMove: (e, gestureState) => {
         if (gestureState.dy > 0) {
-          Animated.event([null, { dy: pan.y }], { useNativeDriver: true })(e, gestureState);
+          Animated.event([null, { dy: pan.y }], { useNativeDriver: false })(e, gestureState);
         }
       },
       onPanResponderRelease: (e, gestureState) => {


### PR DESCRIPTION
As of react native `0.62`, setting useNativeDriver is required to support switching the default in the future.

Reference: https://reactnative.dev/blog/2020/03/26/version-0.62#deprecations