### PR TITLE
Add prop to allow dragging down from any touchable components inside the sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,20 +125,21 @@ renderItem = (item, index) => (
 
 ## Props
 
-| Props            | Type     | Description                                             | Default  |
-| ---------------- | -------- | ------------------------------------------------------- | -------- |
-| animationType    | string   | Background animation ("none", "fade", "slide")          | "none"   |
-| height           | number   | Height of Bottom Sheet                                  | 260      |
-| minClosingHeight | number   | Minimum height of Bottom Sheet before close             | 0        |
-| openDuration     | number   | Open Bottom Sheet animation duration                    | 300 (ms) |
-| closeDuration    | number   | Close Bottom Sheet animation duration                   | 200 (ms) |
-| closeOnDragDown  | boolean  | Use gesture drag down to close Bottom Sheet             | false    |
-| dragFromTopOnly  | boolean  | Drag only the top area of the draggableIcon to close Bottom Sheet instead of the whole content | false    |
-| closeOnPressMask | boolean  | Press the area outside to close Bottom Sheet            | true     |
-| closeOnPressBack | boolean  | Press back android to close Bottom Sheet (Android only) | true     |
-| onClose          | function | Callback function when Bottom Sheet has closed          | null     |
-| onOpen           | function | Callback function when Bottom Sheet has opened          | null     |
-| customStyles     | object   | Custom style to Bottom Sheet                            | {}       |
+| Props                      | Type     | Description                                             | Default  |
+| ---------------------------| -------- | ------------------------------------------------------- | -------- |
+| animationType              | string   | Background animation ("none", "fade", "slide")          | "none"   |
+| height                     | number   | Height of Bottom Sheet                                  | 260      |
+| minClosingHeight           | number   | Minimum height of Bottom Sheet before close             | 0        |
+| openDuration               | number   | Open Bottom Sheet animation duration                    | 300 (ms) |
+| closeDuration              | number   | Close Bottom Sheet animation duration                   | 200 (ms) |
+| closeOnDragDown            | boolean  | Use gesture drag down to close Bottom Sheet             | false    |
+| closeOnTouchablesDragDown  | boolean  | Use gesture drag down on touchable components to close Bottom Sheet<br/> (Doesn't work for touchable components inside a scrollView) <br/> (closeOnDragDown must be enabled for this to work)            | false    |
+| dragFromTopOnly            | boolean  | Drag only the top area of the draggableIcon to close Bottom Sheet instead of the whole content | false    |
+| closeOnPressMask           | boolean  | Press the area outside to close Bottom Sheet            | true     |
+| closeOnPressBack           | boolean  | Press back android to close Bottom Sheet (Android only) | true     |
+| onClose                    | function | Callback function when Bottom Sheet has closed          | null     |
+| onOpen                     | function | Callback function when Bottom Sheet has opened          | null     |
+| customStyles               | object   | Custom style to Bottom Sheet                            | {}       |
 | keyboardAvoidingViewEnabled     | boolean   | Enable KeyboardAvoidingView             | true (ios) |
 
 ### Available Custom Style

--- a/src/index.js
+++ b/src/index.js
@@ -60,10 +60,15 @@ class RBSheet extends Component {
   }
 
   createPanResponder(props) {
-    const { closeOnDragDown, height } = props;
+    const { closeOnDragDown, closeOnTouchablesDragDown, height } = props;
     const { pan } = this.state;
     this.panResponder = PanResponder.create({
       onStartShouldSetPanResponder: () => closeOnDragDown,
+      onMoveShouldSetPanResponder: (e, gestureState) => (
+        (closeOnTouchablesDragDown && closeOnDragDown)
+        && (Math.abs(gestureState.dx) >= 5 
+        || Math.abs(gestureState.dy) >= 5)
+      ),
       onPanResponderMove: (e, gestureState) => {
         if (gestureState.dy > 0) {
           Animated.event([null, { dy: pan.y }], { useNativeDriver: false })(e, gestureState);
@@ -150,6 +155,7 @@ RBSheet.propTypes = {
   openDuration: PropTypes.number,
   closeDuration: PropTypes.number,
   closeOnDragDown: PropTypes.bool,
+  closeOnTouchablesDragDown: PropTypes.bool,
   closeOnPressMask: PropTypes.bool,
   dragFromTopOnly: PropTypes.bool,
   closeOnPressBack: PropTypes.bool,
@@ -167,6 +173,7 @@ RBSheet.defaultProps = {
   openDuration: 300,
   closeDuration: 200,
   closeOnDragDown: false,
+  closeOnTouchablesDragDown: false,
   dragFromTopOnly: false,
   closeOnPressMask: true,
   closeOnPressBack: true,


### PR DESCRIPTION
The new added prop `closeOnTouchablesDragDown`  is there to allow dragging down from gestures on any touchable components inside the bottom sheet. It doesn't affect any current behavior if disabled. And it doesn't affect any touchable components inside a scroll view.

When used the prop enables the pan responder function `onMoveShouldSetPanResponder` and ignores "gestures" that only drags the touchable components less than 5px, and invokes normal touch on that component to allow some moving touches.
```
onMoveShouldSetPanResponder: (e, gestureState) => (
        (closeOnTouchablesDragDown && closeOnDragDown)
        && (Math.abs(gestureState.dx) >= 5 
        || Math.abs(gestureState.dy) >= 5)
      )
```
I added that margin of error (5 px) because I found my self touching the component but my finger was moving slightly while touching so it was capturing it as a gesture.

Here is a demonstration of the feature and the old behavior
<details><summary>The new behavior</summary>

> ![new-TouchableDrag](https://user-images.githubusercontent.com/26524089/85340070-b1b28a80-b4e5-11ea-96b5-46396f4a66e9.gif)
  </details>

<details><summary>The old behavior</summary>

> ![new-noTouchableDrag](https://user-images.githubusercontent.com/26524089/85340085-bbd48900-b4e5-11ea-8bfd-7c4db968f5a4.gif)
  </details>