### PR TITLE
Fix Typings for open and close methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,8 +12,8 @@ declare module "react-native-raw-bottom-sheet" {
     dragFromTopOnly?: boolean;
     closeOnPressMask?: boolean;
     closeOnPressBack?: boolean;
-    onClose?: () => void;
-    onOpen?: () => void;
+    onClose?: (params?: any) => void;
+    onOpen?: (params?: any) => void;
     customStyles?: {
       wrapper?: StyleProp<ViewStyle>;
       container?: StyleProp<ViewStyle>;
@@ -23,7 +23,7 @@ declare module "react-native-raw-bottom-sheet" {
   };
 
   export default class RBSheet extends Component<RBSheetProps> {
-    open(): void;
-    close(): void;
+    open(params?: any): void;
+    close(params?: any): void;
   }
 }


### PR DESCRIPTION
This fixes the Typings for `open` and `close` methods, which are both allowed to have params