### PR TITLE
support changing height while the sheet is open if needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,19 @@ class RBSheet extends Component {
     this.createPanResponder(props);
   }
 
+  componentDidUpdate(prevProps) {
+    const { height: prevHeight } = prevProps;
+    const { height, openDuration, closeDuration } = this.props;
+    const { modalVisible, animatedHeight } = this.state;
+    if (height !== prevHeight && modalVisible) {
+      Animated.timing(animatedHeight, {
+        useNativeDriver: false,
+        toValue: height,
+        duration: height < prevHeight ? closeDuration : openDuration,
+      }).start();
+    }
+  }
+
   setModalVisible(visible, props) {
     const { height, minClosingHeight, openDuration, closeDuration, onClose, onOpen } = this.props;
     const { animatedHeight, pan } = this.state;


### PR DESCRIPTION
Thanks for this excellent and simple library!

For one of our use case, we need to change the contents of the sheet while it is open, in a way that requires the `height` to change. However, because `height` is not used directly in the component but rather as an animated value, this does not work right with the current version of `react-native-raw-bottom-sheet`.

This PR notices changes to the `height` property while the sheet is open, and animates to the new height if necessary.

Thanks!