### PR TITLE
fixed ts error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ declare module "react-native-raw-bottom-sheet" {
       draggableIcon?: StyleProp<ViewStyle>;
     };
     keyboardAvoidingViewEnabled?: boolean;
+    children?: ReactNode
   };
 
   export default class RBSheet extends Component<RBSheetProps> {


### PR DESCRIPTION
Simple solution to fix this ts error 
TS2769: No overload matches this call.   Overload 1 of 2, '(props: RBSheetProps | Readonly<RBSheetProps>): RBSheet', gave the following error.     Type '{ children: Element; ref: ForwardedRef<RBSheet>; height: number; closeOnDragDown: true; closeOnPressMask: true; customStyles: { container: { borderTopLeftRadius: number; borderTopRightRadius: number; paddingHorizontal: string; }; draggableIcon: { ...; }; }; keyboardAvoidingViewEnabled: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RBSheet> & Readonly<RBSheetProps>'.       Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RBSheet> & Readonly<RBSheetProps>'.   Overload 2 of 2, '(props: RBSheetProps, context: any): RBSheet', gave the following error.     Type '{ children: Element; ref: ForwardedRef<RBSheet>; height: number; closeOnDragDown: true; closeOnPressMask: true; customStyles: { container: { borderTopLeftRadius: number; borderTopRightRadius: number; paddingHorizontal: string; }; draggableIcon: { ...; }; }; keyboardAvoidingViewEnabled: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RBSheet> & Readonly<RBSheetProps>'.       Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RBSheet> & Readonly<RBSheetProps>'