### PR TITLE
Issue resolved: Style property 'height' is not supported by native animated module.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ const RBSheet = forwardRef((props, ref) => {
   // Function to handle the visibility of the modal
   const handleSetVisible = visible => {
     if (visible) {
-      // panY.setValue(0); // reset drag first
+      panY.setValue(0); // reset drag first
       translateY.setValue(height); // start hidden
       setModalVisible(true);
       if (typeof onOpen === 'function') {
@@ -101,7 +101,7 @@ const RBSheet = forwardRef((props, ref) => {
         duration: closeDuration,
       }).start(() => {
         translateY.setValue(height); // reset for next open
-        // panY.setValue(0); // reset drag too
+        panY.setValue(0); // reset drag too
         setModalVisible(false);
         if (typeof onClose === 'function') {
           onClose();


### PR DESCRIPTION
Issue resolved: Style property 'height' is not supported by native animated module

This issue is caused by using native driver true with height animation. And nativeDriver only only allows opacity and transform styling for animation.